### PR TITLE
fix precision

### DIFF
--- a/cb-sol-cli/cmd/erc20.js
+++ b/cb-sol-cli/cmd/erc20.js
@@ -91,7 +91,7 @@ const balanceCmd = new Command("balance")
         const erc20Instance = new ethers.Contract(args.erc20Address, constants.ContractABIs.Erc20Mintable.abi, args.wallet);
         const balance = await erc20Instance.balanceOf(args.address)
         const decimals = await erc20Instance.decimals();
-        log(args, `Account ${args.address} has a balance of ${balance / 10 ** decimals}` )
+        log(args, `Account ${args.address} has a balance of ${ethers.utils.formatUnits(balance, decimals)}` )
     })
 
 const allowanceCmd = new Command("allowance")


### PR DESCRIPTION
Fixes precision issue with a console.log

To test it:
View user balance [here](https://etherscan.io/token/0x1f9840a85d5af5bf1d1762f925bdaddc4201f984?a=0x9f41cecc435101045ea9f41d4ee8c5353f77e5d5) and run:
```
node index.js --url $INFURA erc20 balance --address 0x9f41cecc435101045ea9f41d4ee8c5353f77e5d5 --erc20Address 0x1f9840a85d5af5bf1d1762f925bdaddc4201f984
```