### PR TITLE
Fix constructor arguments when deploy contract GenericHandler

### DIFF
--- a/cb-sol-cli/cmd/deploy.js
+++ b/cb-sol-cli/cmd/deploy.js
@@ -192,7 +192,7 @@ async function deployERC721Handler(args) {
 
 async function deployGenericHandler(args) {
     const factory = new ethers.ContractFactory(constants.ContractABIs.GenericHandler.abi, constants.ContractABIs.GenericHandler.bytecode, args.wallet)
-    const contract = await factory.deploy(args.bridgeContract, [], [], [], [], { gasPrice: args.gasPrice, gasLimit: args.gasLimit})
+    const contract = await factory.deploy(args.bridgeContract, [], [], [], [], [], { gasPrice: args.gasPrice, gasLimit: args.gasLimit})
     await contract.deployed();
     args.genericHandlerContract = contract.address
     console.log("✓ GenericHandler contract deployed")


### PR DESCRIPTION
Fix constructor arguments when deploy contract GenericHandler

## Description

Let's see that latest GenericHanlder contructor is :

```sh
  constructor(
      address          bridgeAddress,
      bytes32[] memory initialResourceIDs,
      address[] memory initialContractAddresses,
      bytes4[]  memory initialDepositFunctionSignatures,
      uint256[] memory initialDepositFunctionDepositerOffsets,
      bytes4[]  memory initialExecuteFunctionSignatures
  )
```

Which has 6 arguments required, however we only give five arguments within deploy command source code. So here we fix this by giving an empty array.

## Related Issue Or Context
None

## How Has This Been Tested? Testing details.

```sh
node index.js --url http://localhost:8545 --privateKey <your private key> --all --relayerThreshold 1
```
## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have commented my code, particularly in hard-to-understand areas.
- [ x ] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ x ] I have updated the documentation locally and in chainbridge-docs.
- [ x ] I have added tests to cover my changes.
- [ ] I have ensured that all the checks are passing and green, I've signed the CLA bot
