### PR TITLE
Add name, symbol and baseURI arguments for erc721 deployments

### DIFF
--- a/cb-sol-cli/cmd/deploy.js
+++ b/cb-sol-cli/cmd/deploy.js
@@ -21,6 +21,9 @@ const deployCmd = new Command("deploy")
     .option('--erc20Name <name>', 'Symbol for the erc20 contract', "")
     .option('--erc20Decimals <amount>', 'Decimals for erc20 contract', 18)
     .option('--erc721', 'Deploy erc721 contract')
+    .option('--erc721Symbol <symbol>', 'Name for the erc721 contract', "")
+    .option('--erc721Name <name>', 'Symbol for the erc721 contract', "")
+    .option('--erc721BaseUri <uri>', 'Base URI for the erc721 contract', "")
     .option('--centAsset', 'Deploy centrifuge asset contract')
     .option('--wetc', 'Deploy wrapped ETC Erc20 contract')
     .option('--config', 'Logs the configuration based on the deployment', false)
@@ -169,7 +172,7 @@ async function deployERC20(args) {
 async function deployERC20Handler(args) {
     if (!isValidAddress(args.bridgeAddress)) {
         console.log("ERC20Handler contract failed to deploy due to invalid bridge address")
-        return 
+        return
     }
     const factory = new ethers.ContractFactory(constants.ContractABIs.Erc20Handler.abi, constants.ContractABIs.Erc20Handler.bytecode, args.wallet);
     const contract = await factory.deploy(args.bridgeAddress, [], [], [], { gasPrice: args.gasPrice, gasLimit: args.gasLimit});
@@ -180,7 +183,7 @@ async function deployERC20Handler(args) {
 
 async function deployERC721(args) {
     const factory = new ethers.ContractFactory(constants.ContractABIs.Erc721Mintable.abi, constants.ContractABIs.Erc721Mintable.bytecode, args.wallet);
-    const contract = await factory.deploy("", "", "", { gasPrice: args.gasPrice, gasLimit: args.gasLimit});
+    const contract = await factory.deploy(args.erc721Name, args.erc721Symbol, args.erc721BaseUri, { gasPrice: args.gasPrice, gasLimit: args.gasLimit});
     await contract.deployed();
     args.erc721Contract = contract.address
     console.log("✓ ERC721 contract deployed")
@@ -189,7 +192,7 @@ async function deployERC721(args) {
 async function deployERC721Handler(args) {
     if (!isValidAddress(args.bridgeAddress)) {
         console.log("ERC721Handler contract failed to deploy due to invalid bridge address")
-        return 
+        return
     }
     const factory = new ethers.ContractFactory(constants.ContractABIs.Erc721Handler.abi, constants.ContractABIs.Erc721Handler.bytecode, args.wallet);
     const contract = await factory.deploy(args.bridgeAddress,[],[],[], { gasPrice: args.gasPrice, gasLimit: args.gasLimit});
@@ -201,7 +204,7 @@ async function deployERC721Handler(args) {
 async function deployGenericHandler(args) {
     if (!isValidAddress(args.bridgeAddress)) {
         console.log("GenericHandler contract failed to deploy due to invalid bridge address")
-        return 
+        return
     }
     const factory = new ethers.ContractFactory(constants.ContractABIs.GenericHandler.abi, constants.ContractABIs.GenericHandler.bytecode, args.wallet)
     const contract = await factory.deploy(args.bridgeAddress, [], [], [], [], { gasPrice: args.gasPrice, gasLimit: args.gasLimit})


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Allow the user to pass a name, symbol and baseUri when deploying a ERC721.

## How Has This Been Tested? Testing details.

We have tested the changes on a private IBFT network and also on Rinkeby.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [x] I have updated the documentation locally and in chainbridge-docs.
- [x] I have added tests to cover my changes.
- [x] I have ensured that all the checks are passing and green, I've signed the CLA bot
