### PR TITLE
Added gasPrice, gasLimit parameters for add-minter

### DIFF
--- a/cb-sol-cli/cmd/erc20.js
+++ b/cb-sol-cli/cmd/erc20.js
@@ -26,7 +26,7 @@ const addMinterCmd = new Command("add-minter")
         const erc20Instance = new ethers.Contract(args.erc20Address, constants.ContractABIs.Erc20Mintable.abi, args.wallet);
         let MINTER_ROLE = await erc20Instance.MINTER_ROLE();
         log(args, `Adding ${args.minter} as a minter on contract ${args.erc20Address}`);
-        const tx = await erc20Instance.grantRole(MINTER_ROLE, args.minter);
+        const tx = await erc20Instance.grantRole(MINTER_ROLE, args.minter, { gasPrice: args.gasPrice, gasLimit: args.gasLimit});
         await waitForTx(args.provider, tx.hash)
     })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The command add-minter does not have the next parameters { gasPrice: args.gasPrice, gasLimit: args.gasLimit}
That is why it is not possible to add custom values related to the private network. 

## Related Issue Or Context
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change here -->

Closes: #<issue>

## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [ ] I have added tests to cover my changes.
- [ ] I have ensured that all the checks are passing and green, I've signed the CLA bot
